### PR TITLE
Allow using typedef as the type of "args"

### DIFF
--- a/src/ufront/web/ControllerMacros.hx
+++ b/src/ufront/web/ControllerMacros.hx
@@ -402,7 +402,7 @@ class ControllerMacros {
 			case TPath(_):
 				switch (type.toType()) 
 				{
-					case TType(t, parmas):
+					case TType(t, params):
 						return parseArgsArgument( t.get().type.toComplexType(), allOptional, pos );
 					case _:
 				}


### PR DESCRIPTION
Currently `args` in a controller function only accepts anonymous type. This fix allows typedef (of anonymous type) as well.